### PR TITLE
Loading indicator

### DIFF
--- a/qml/AddShow.qml
+++ b/qml/AddShow.qml
@@ -10,7 +10,7 @@ Page {
     Header {
         id: header
         text: "Add show"
-        busy: series_manager.isSearching
+        updating: series_manager.isSearching
     }
 
     TextField {

--- a/qml/Header.qml
+++ b/qml/Header.qml
@@ -10,7 +10,7 @@ Item {
 
     property alias text: label.text
     property bool hasRefreshAction: false
-    property bool busy: false
+    property bool updating: false
     property alias anchorPoint: refreshAction.left
     property alias textWidth: label.width
     signal refreshActionActivated()
@@ -35,27 +35,27 @@ Item {
         anchors.rightMargin: 10
         width: refreshIcon.width
         height: refreshIcon.height
-        visible: hasRefreshAction || busy
+        visible: hasRefreshAction || updating
 
         Image {
             id: refreshIcon
             source: 'icons/refresh-icon.png'
-            visible: !busy && hasRefreshAction
+            visible: !updating && hasRefreshAction
         }
 
         BusyIndicator {
             id: busyIndicator
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter
-            visible: busy
-            running: busy
+            visible: updating
+            running: updating
             platformStyle: BusyIndicatorStyle {
                                 spinnerFrames: "image://theme/spinnerinverted"
                            }
         }
 
         MouseArea {
-            enabled: !busy && hasRefreshAction
+            enabled: !updating && hasRefreshAction
             anchors.fill: parent
             onClicked: { header.refreshActionActivated() }
         }

--- a/qml/SeriesPage.qml
+++ b/qml/SeriesPage.qml
@@ -8,8 +8,8 @@ Page {
     Header {
        id: header;
        text: "SeriesFinale"
-       busy: series_manager.busy
-       hasRefreshAction: !emptyText.visible
+       updating: series_manager.updating
+       hasRefreshAction: !emptyText.visible && !loadingIndicator.visible
        onRefreshActionActivated: series_manager.update_all_shows_episodes()
     }
 
@@ -23,11 +23,22 @@ Page {
         model: seriesList
         interactive: !emptyText.visible
 
+        BusyIndicator {
+            id: loadingIndicator
+            running: series_manager.loading
+            visible: series_manager.loading
+            anchors.verticalCenter: parent.verticalCenter
+            anchors.horizontalCenter: parent.horizontalCenter
+            platformStyle: BusyIndicatorStyle {
+                size: "large"
+            }
+        }
+
         Text {
             id: emptyText
             text: 'No shows were added so far'
             font.pixelSize: 32
-            visible: listView.count == 0
+            visible: listView.count == 0 && !series_manager.loading
             color: 'white'
             anchors.verticalCenter: parent.verticalCenter
             anchors.horizontalCenter: parent.horizontalCenter

--- a/qml/ShowPage.qml
+++ b/qml/ShowPage.qml
@@ -97,7 +97,7 @@ Page {
         Header {
             id: header
             text: show.showName
-            busy: show.busy
+            updating: show.updating
             hasRefreshAction: true
             onRefreshActionActivated: series_manager.update_show_episodes(show)
             textWidth: header.width - infoIcon.width * 2.5


### PR DESCRIPTION
Split the 'busy' signal between 'updating' and 'loading', so when
loading a big indicator is shown.

This avoid showing "No shows available" when loading them.
